### PR TITLE
RuntimeTypeModel exposed as public & lazy

### DIFF
--- a/src/WebApiContrib.Formatting.ProtoBuf/ProtoBufFormatter.cs
+++ b/src/WebApiContrib.Formatting.ProtoBuf/ProtoBufFormatter.cs
@@ -12,12 +12,15 @@ namespace WebApiContrib.Formatting
     public class ProtoBufFormatter : MediaTypeFormatter
     {
         private static readonly MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("application/x-protobuf");
-        private static readonly RuntimeTypeModel model = TypeModel.Create();
+        private static Lazy<RuntimeTypeModel> model = new Lazy<RuntimeTypeModel>(CreateTypeModel);
+
+        public static RuntimeTypeModel Model
+        {
+            get { return model.Value; }
+        }
 
         public ProtoBufFormatter()
         {
-            model.UseImplicitZeroDefaults = false;
-
             SupportedMediaTypes.Add(mediaType);
         }
 
@@ -42,7 +45,7 @@ namespace WebApiContrib.Formatting
 
             try
             {
-                object result = model.Deserialize(stream, null, type);
+                object result = Model.Deserialize(stream, null, type);
                 tcs.SetResult(result);
             }
             catch (Exception ex)
@@ -59,7 +62,7 @@ namespace WebApiContrib.Formatting
 
             try
             {
-                model.Serialize(stream, value);
+                Model.Serialize(stream, value);
                 tcs.SetResult(null);
             }
             catch (Exception ex)
@@ -68,6 +71,13 @@ namespace WebApiContrib.Formatting
             }
 
             return tcs.Task;
+        }
+
+        private static RuntimeTypeModel CreateTypeModel()
+        {
+            var typeModel = TypeModel.Create();
+            typeModel.UseImplicitZeroDefaults = false;
+            return typeModel;
         }
 
         private static bool CanReadTypeCore(Type type)

--- a/src/WebApiContrib.Formatting.ProtoBuf/WebApiContrib.Formatting.ProtoBuf.csproj
+++ b/src/WebApiContrib.Formatting.ProtoBuf/WebApiContrib.Formatting.ProtoBuf.csproj
@@ -33,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="protobuf-net">
       <HintPath>..\..\packages\protobuf-net.2.0.0.480\lib\net40\protobuf-net.dll</HintPath>
     </Reference>

--- a/src/WebApiContrib.Formatting.ProtoBuf/packages.config
+++ b/src/WebApiContrib.Formatting.ProtoBuf/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net40" />
   <package id="protobuf-net" version="2.0.0.480" />
 </packages>


### PR DESCRIPTION
Changed RuntimeTypeModel to be public. It is common in ProtoBuf usage to precompile types, which was not possible with the previous solution. Now you can something like that from for example global config:

```
        ProtoBufFormatter.Model.Add(typeof(MyType),false);
        ProtoBufFormatter.Model.Compile();
```

Additionally made it Lazy so that the formatter can be added to formatters collection without much footprint. Also removed dependency on JSON.NET (not used in this project at all).
